### PR TITLE
Add recognizer restart API

### DIFF
--- a/Assets/Scripts/VoskSpeechToText.cs
+++ b/Assets/Scripts/VoskSpeechToText.cs
@@ -247,12 +247,40 @@ public class VoskSpeechToText : MonoBehaviour
 		}
 	}
 
-	//Wait until microphones are initialized
-	private IEnumerator WaitForMicrophoneInput()
-	{
-		while (Microphone.devices.Length <= 0)
-			yield return null;
-	}
+        //Wait until microphones are initialized
+        private IEnumerator WaitForMicrophoneInput()
+        {
+                while (Microphone.devices.Length <= 0)
+                        yield return null;
+        }
+
+        /// <summary>
+        /// Restart the recognizer with a new model and optional key phrases.
+        /// </summary>
+        /// <param name="newModel">Preloaded Vosk model to use.</param>
+        /// <param name="newKeyPhrases">List of key phrases for the new model.</param>
+        public void RestartRecognizer(Model newModel, List<string> newKeyPhrases)
+        {
+                // Stop current recording if needed
+                if (VoiceProcessor.IsRecording)
+                {
+                        _running = false;
+                        VoiceProcessor.StopRecording();
+                }
+
+                // Dispose existing recognizer and model
+                _recognizer?.Dispose();
+                _recognizer = null;
+                _model?.Dispose();
+
+                _model = newModel;
+                KeyPhrases = newKeyPhrases ?? new List<string>();
+
+                // allow new recognizer to be created in ThreadedWork
+                _recognizerReady = false;
+
+                ToggleRecording();
+        }
 
 	//Can be called from a script or a GUI button to start detection.
 	public void ToggleRecording()

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ public class VoskExample : MonoBehaviour
 }
 ```
 
+### Switching Models at Runtime
+
+You can change the recogniser model and key phrases without restarting the
+application by calling `RestartRecognizer` with a preloaded `Model` instance:
+
+```csharp
+// assuming `speech` is an initialised VoskSpeechToText component
+var newModel = new Model(pathToNewModel);
+var phrases = new List<string> { "hello", "world" };
+speech.RestartRecognizer(newModel, phrases);
+```
+
 For more information on models and Vosk itself see the [Vosk documentation](https://github.com/alphacep/vosk-api).
 
 ## License


### PR DESCRIPTION
## Summary
- add `RestartRecognizer` for switching models at runtime
- update readme with example of runtime model change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c59203e88331b6a2c85af2886efb