### PR TITLE
Add keyphrase editor toolbar

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ccf27e083e3c403086c7d611df3a5b84
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Editor/VoskKeyphraseToolbar.cs
+++ b/Assets/Editor/VoskKeyphraseToolbar.cs
@@ -1,0 +1,75 @@
+using UnityEditor;
+using UnityEngine;
+
+public class VoskKeyphraseToolbar : EditorWindow
+{
+    private VoskSpeechToText _speech;
+    private SerializedObject _serializedSpeech;
+    private SerializedProperty _keyPhrasesProp;
+    private string _newPhrase = "";
+
+    [MenuItem("Window/Vosk/Keyphrase Toolbar")] 
+    public static void ShowWindow()
+    {
+        GetWindow<VoskKeyphraseToolbar>("Keyphrase Toolbar");
+    }
+
+    private void OnFocus()
+    {
+        UpdateSelection();
+    }
+
+    private void OnSelectionChange()
+    {
+        UpdateSelection();
+        Repaint();
+    }
+
+    private void UpdateSelection()
+    {
+        _speech = null;
+        _serializedSpeech = null;
+        _keyPhrasesProp = null;
+        if (Selection.activeGameObject != null)
+        {
+            _speech = Selection.activeGameObject.GetComponent<VoskSpeechToText>();
+            if (_speech != null)
+            {
+                _serializedSpeech = new SerializedObject(_speech);
+                _keyPhrasesProp = _serializedSpeech.FindProperty("KeyPhrases");
+            }
+        }
+    }
+
+    private void OnGUI()
+    {
+        GUILayout.Label("Keyphrases", EditorStyles.boldLabel);
+        if (_keyPhrasesProp == null)
+        {
+            EditorGUILayout.HelpBox("Select a GameObject with VoskSpeechToText to edit its keyphrases.", MessageType.Info);
+            return;
+        }
+
+        _serializedSpeech.Update();
+        EditorGUILayout.PropertyField(_keyPhrasesProp, true);
+
+        EditorGUILayout.BeginHorizontal();
+        _newPhrase = EditorGUILayout.TextField(_newPhrase);
+        if (GUILayout.Button("Add", GUILayout.Width(50)))
+        {
+            if (!string.IsNullOrEmpty(_newPhrase))
+            {
+                _keyPhrasesProp.arraySize++;
+                _keyPhrasesProp.GetArrayElementAtIndex(_keyPhrasesProp.arraySize - 1).stringValue = _newPhrase;
+                _newPhrase = "";
+            }
+        }
+        EditorGUILayout.EndHorizontal();
+
+        if (GUILayout.Button("Apply"))
+        {
+            _serializedSpeech.ApplyModifiedProperties();
+            EditorUtility.SetDirty(_speech);
+        }
+    }
+}

--- a/Assets/Editor/VoskKeyphraseToolbar.cs.meta
+++ b/Assets/Editor/VoskKeyphraseToolbar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c8afe5e76df48c8a157f88b023265c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add an Editor folder with meta file
- implement a new `VoskKeyphraseToolbar` editor window

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6841c84a29748331a613de0f9e1209f1