### PR TITLE
Add HelloWorld detection example

### DIFF
--- a/Assets/Scripts/HelloWorldExample.cs
+++ b/Assets/Scripts/HelloWorldExample.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+public class HelloWorldExample : MonoBehaviour
+{
+    public VoskSpeechToText speech;
+
+    void Start()
+    {
+        if (speech == null)
+        {
+            speech = GetComponent<VoskSpeechToText>();
+        }
+
+        speech.OnTranscriptionResult += OnResult;
+
+        // Start the recogniser and microphone if AutoStart is disabled
+        if (!speech.AutoStart)
+        {
+            speech.StartVoskStt(startMicrophone: true);
+        }
+    }
+
+    private void OnResult(string json)
+    {
+        var result = new RecognitionResult(json);
+        foreach (var phrase in result.Phrases)
+        {
+            if (phrase.Text.ToLower().Contains("hello"))
+            {
+                Debug.Log("hello world");
+                break;
+            }
+        }
+    }
+
+    void OnDestroy()
+    {
+        speech.OnTranscriptionResult -= OnResult;
+    }
+}

--- a/Assets/Scripts/HelloWorldExample.cs.meta
+++ b/Assets/Scripts/HelloWorldExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 076cba409ef04dc797dc5ca49d1f0c43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,40 @@ public class VoskExample : MonoBehaviour
 }
 ```
 
+## Hello World Example
+
+The following example shows how to detect the word `"hello"` and print `"hello world"` to the console.
+
+```csharp
+using UnityEngine;
+
+public class HelloWorldExample : MonoBehaviour
+{
+    public VoskSpeechToText speech;
+
+    void Start()
+    {
+        speech.OnTranscriptionResult += OnResult;
+        speech.StartVoskStt(startMicrophone: true);
+    }
+
+    void OnResult(string json)
+    {
+        var result = new RecognitionResult(json);
+        foreach (var phrase in result.Phrases)
+        {
+            if (phrase.Text.ToLower().Contains("hello"))
+            {
+                Debug.Log("hello world");
+                break;
+            }
+        }
+    }
+}
+```
+
+Attach this component alongside `VoskSpeechToText`. When you say `"hello"` the console will output `"hello world"`.
+
 For more information on models and Vosk itself see the [Vosk documentation](https://github.com/alphacep/vosk-api).
 
 ## License


### PR DESCRIPTION
## Summary
- add `HelloWorldExample` script showing how to detect the word "hello"
- document the new example in README

## Testing
- `echo "No tests present" && true`


------
https://chatgpt.com/codex/tasks/task_e_6841d0cded7c8331a730b23ec1631c2a