### PR TITLE
Fix null reference for voice processor

### DIFF
--- a/Assets/Scripts/HelloWorldExample.cs
+++ b/Assets/Scripts/HelloWorldExample.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+public class HelloWorldExample : MonoBehaviour
+{
+    public VoskSpeechToText speech;
+
+    void Start()
+    {
+        if (speech == null)
+        {
+            speech = GetComponent<VoskSpeechToText>();
+        }
+
+        speech.OnTranscriptionResult += OnResult;
+
+        // Start the recogniser and microphone if AutoStart is disabled
+        if (!speech.AutoStart)
+        {
+            speech.StartVoskStt(startMicrophone: true);
+        }
+    }
+
+    private void OnResult(string json)
+    {
+        var result = new RecognitionResult(json);
+        foreach (var phrase in result.Phrases)
+        {
+            if (phrase.Text.ToLower().Contains("hello"))
+            {
+                Debug.Log("hello world");
+                break;
+            }
+        }
+    }
+
+    void OnDestroy()
+    {
+        speech.OnTranscriptionResult -= OnResult;
+    }
+}

--- a/Assets/Scripts/HelloWorldExample.cs.meta
+++ b/Assets/Scripts/HelloWorldExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 076cba409ef04dc797dc5ca49d1f0c43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/VoskSpeechToText.cs
+++ b/Assets/Scripts/VoskSpeechToText.cs
@@ -14,12 +14,11 @@ using Vosk;
 
 public class VoskSpeechToText : MonoBehaviour
 {
-	[Tooltip("Location of the model, relative to the Streaming Assets folder.")]
-	public string ModelPath = "vosk-model-small-ru-0.22.zip";
+        [Tooltip("Location of the model, relative to the Streaming Assets folder.")]
+        public string ModelPath = "vosk-model-small-ru-0.22.zip";
 
-	[Tooltip("The source of the microphone input.")]
-
-	public VoiceProcessor VoiceProcessor;
+        [Tooltip("The source of the microphone input.")]
+        public VoiceProcessor VoiceProcessor;
 	[Tooltip("The Max number of alternatives that will be processed.")]
 	public int MaxAlternatives = 3;
 
@@ -76,6 +75,18 @@ public class VoskSpeechToText : MonoBehaviour
 
 	//Thread safe queue of resuts
 	private readonly ConcurrentQueue<string> _threadedResultQueue = new ConcurrentQueue<string>();
+        void Awake()
+        {
+                if (VoiceProcessor == null)
+                {
+                        VoiceProcessor = GetComponent<VoiceProcessor>();
+                        if (VoiceProcessor == null)
+                        {
+                                VoiceProcessor = gameObject.AddComponent<VoiceProcessor>();
+                        }
+                }
+        }
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ You can assign a different model by changing `ModelPath` in the inspector or thr
 
 1. Add the **VoskSpeechToText** component to a GameObject in your scene.
 2. Place a Vosk model archive into `Assets/StreamingAssets/` and assign its filename to `ModelPath`.
-3. Call `StartVoskStt` (optionally with `startMicrophone: true`) to initialise the recogniser.
-4. Subscribe to `OnTranscriptionResult` to receive the recognised text.
+3. A `VoiceProcessor` component is required for microphone input. If one isn't present on the same GameObject, `VoskSpeechToText` adds it automatically.
+4. Call `StartVoskStt` (optionally with `startMicrophone: true`) to initialise the recogniser.
+5. Subscribe to `OnTranscriptionResult` to receive the recognised text.
 
 ```csharp
 using UnityEngine;
@@ -49,6 +50,40 @@ public class VoskExample : MonoBehaviour
     }
 }
 ```
+
+## Hello World Example
+
+The following example shows how to detect the word `"hello"` and print `"hello world"` to the console.
+
+```csharp
+using UnityEngine;
+
+public class HelloWorldExample : MonoBehaviour
+{
+    public VoskSpeechToText speech;
+
+    void Start()
+    {
+        speech.OnTranscriptionResult += OnResult;
+        speech.StartVoskStt(startMicrophone: true);
+    }
+
+    void OnResult(string json)
+    {
+        var result = new RecognitionResult(json);
+        foreach (var phrase in result.Phrases)
+        {
+            if (phrase.Text.ToLower().Contains("hello"))
+            {
+                Debug.Log("hello world");
+                break;
+            }
+        }
+    }
+}
+```
+
+Attach this component alongside `VoskSpeechToText`. When you say `"hello"` the console will output `"hello world"`.
 
 For more information on models and Vosk itself see the [Vosk documentation](https://github.com/alphacep/vosk-api).
 


### PR DESCRIPTION
## Summary
- avoid `NullReferenceException` by auto-adding a `VoiceProcessor`
- document the automatic `VoiceProcessor` addition in the usage steps

## Testing
- `echo "No tests present" && true`

------
https://chatgpt.com/codex/tasks/task_e_6841d0cded7c8331a730b23ec1631c2a